### PR TITLE
polyfill: Rename BindingIdentifier of function expression

### DIFF
--- a/polyfill.js
+++ b/polyfill.js
@@ -3,7 +3,7 @@ if (typeof Promise !== 'function') {
 }
 
 if (typeof Promise.try !== 'function') {
-	Promise.try = function try(func) {
+	Promise.try = function PromiseTry(func) {
 		if (typeof this !== 'function')) {
 			throw new TypeError('Receiver must be a constructor');
 		}


### PR DESCRIPTION
My understanding is that [FunctionExpression](https://tc39.github.io/ecma262/#prod-FunctionExpression)'s [BindingIdentifier](https://tc39.github.io/ecma262/#prod-BindingIdentifier) disallow to use [ReservedWord](https://tc39.github.io/ecma262/#prod-ReservedWord).
`try` is a parts of [Keyword](https://tc39.github.io/ecma262/#prod-Keyword).
